### PR TITLE
Add Set active option for projects

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -244,9 +244,10 @@
     },
     "actions": {
       "currentActive": "Current project",
-      "setActive": "Open project",
+      "openProject": "Open project",
       "edit": "Edit project",
       "editDetails": "Project details",
+      "setActive": "Set to active",
       "duplicate": "Duplicate project",
       "export": "Download backup",
       "delete": "Delete project",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -247,7 +247,7 @@
       "openProject": "Open project",
       "edit": "Edit project",
       "editDetails": "Project details",
-      "setActive": "Set to active",
+      "setActive": "Set as active project",
       "duplicate": "Duplicate project",
       "export": "Download backup",
       "delete": "Delete project",

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -10,6 +10,7 @@ import {
   Download,
   ArrowUpCircle,
   MoreVertical,
+  Check,
 } from "lucide-react";
 
 import PageLayout from "../components/layout/PageLayout";
@@ -26,7 +27,7 @@ import {
   getAllProjects,
   deleteProject,
   duplicateProject,
-  setActiveProject as activateProject,
+  setActiveProject,
   exportProject,
 } from "../queries/projectManager";
 import { sortItemsByCopyName } from "../utils/copyNameSort";
@@ -137,17 +138,21 @@ export default function Projects() {
     });
   };
 
+  const activateProject = async (project, { showToast: showSuccessToast = true } = {}) => {
+    if (activeProject?.id === project.id) {
+      return;
+    }
+    await setActiveProject(project.id);
+    await fetchActiveProject();
+    await loadProjects();
+    if (showSuccessToast) {
+      showToast(t("projects.toasts.setActiveSuccess", { name: project.name }), "success");
+    }
+  };
+
   const openProjectWorkspace = async (project, { showActivationToast = true } = {}) => {
     try {
-      if (!activeProject || activeProject.id !== project.id) {
-        await activateProject(project.id);
-        await fetchActiveProject();
-        await loadProjects();
-        if (showActivationToast) {
-          showToast(t("projects.toasts.setActiveSuccess", { name: project.name }), "success");
-        }
-      }
-
+      await activateProject(project, { showToast: showActivationToast });
       navigate(workspaceDestination);
     } catch (error) {
       console.error("Failed to open project:", error);
@@ -332,7 +337,7 @@ export default function Projects() {
                             className={`${menuButtonClass} text-slate-700 hover:bg-slate-50`}
                           >
                             <FolderOpen size={14} />
-                            {t("projects.actions.setActive")}
+                            {t("projects.actions.openProject")}
                           </button>
                           <div className="my-1 border-t border-slate-200" />
                           <Link
@@ -354,6 +359,21 @@ export default function Projects() {
                             <Copy size={14} />
                             {t("projects.actions.duplicate")}
                           </button>
+                          {!isCurrentProject && (
+                            <>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setOpenMenuId(null);
+                                  activateProject(project);
+                                }}
+                                className={`${menuButtonClass} text-slate-700 hover:bg-slate-50`}
+                              >
+                                <Check size={14} />
+                                {t("projects.actions.setActive")}
+                              </button>
+                            </>
+                          )}
                           <button
                             type="button"
                             onClick={() => {

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -138,25 +138,29 @@ export default function Projects() {
     });
   };
 
-  const activateProject = async (project, { showToast: showSuccessToast = true } = {}) => {
+  const activateProject = async (project, { silent = false } = {}) => {
     if (activeProject?.id === project.id) {
-      return;
+      return true;
     }
-    await setActiveProject(project.id);
-    await fetchActiveProject();
-    await loadProjects();
-    if (showSuccessToast) {
-      showToast(t("projects.toasts.setActiveSuccess", { name: project.name }), "success");
+    try {
+      await setActiveProject(project.id);
+      await fetchActiveProject();
+      await loadProjects();
+      if (!silent) {
+        showToast(t("projects.toasts.setActiveSuccess", { name: project.name }), "success");
+      }
+      return true;
+    } catch (error) {
+      console.error("Failed to set active project:", error);
+      showToast(t("projects.toasts.setActiveError"), "error");
+      return false;
     }
   };
 
   const openProjectWorkspace = async (project, { showActivationToast = true } = {}) => {
-    try {
-      await activateProject(project, { showToast: showActivationToast });
+    const activated = await activateProject(project, { silent: !showActivationToast });
+    if (activated) {
       navigate(workspaceDestination);
-    } catch (error) {
-      console.error("Failed to open project:", error);
-      showToast(t("projects.toasts.setActiveError"), "error");
     }
   };
 
@@ -339,6 +343,19 @@ export default function Projects() {
                             <FolderOpen size={14} />
                             {t("projects.actions.openProject")}
                           </button>
+                          {!isCurrentProject && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setOpenMenuId(null);
+                                activateProject(project);
+                              }}
+                              className={`${menuButtonClass} text-slate-700 hover:bg-slate-50`}
+                            >
+                              <Check size={14} />
+                              {t("projects.actions.setActive")}
+                            </button>
+                          )}
                           <div className="my-1 border-t border-slate-200" />
                           <Link
                             to={`/projects/edit/${project.id}`}
@@ -359,21 +376,6 @@ export default function Projects() {
                             <Copy size={14} />
                             {t("projects.actions.duplicate")}
                           </button>
-                          {!isCurrentProject && (
-                            <>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setOpenMenuId(null);
-                                  activateProject(project);
-                                }}
-                                className={`${menuButtonClass} text-slate-700 hover:bg-slate-50`}
-                              >
-                                <Check size={14} />
-                                {t("projects.actions.setActive")}
-                              </button>
-                            </>
-                          )}
                           <button
                             type="button"
                             onClick={() => {


### PR DESCRIPTION
## Issue
You cannot quickly activate a project, in order to delete another one.
You have to navigate a project, go back to Projects and then delete.

## Solution
Added the option to Set Active a project without opening it.
_(The option is visible only on inactive projects)_

<img width="1022" height="816" alt="CleanShot 2026-05-08 at 13 20 05@2x" src="https://github.com/user-attachments/assets/f6f4074a-46d6-47af-8e51-223a2595f58e" />
