### PR TITLE
Autofill menu item's labels on page change

### DIFF
--- a/src/components/menus/MenuEditor/SortableItem.jsx
+++ b/src/components/menus/MenuEditor/SortableItem.jsx
@@ -4,6 +4,7 @@ import { ChevronRight, ChevronDown, GripVertical, Plus, Trash2 } from "lucide-re
 import { IconButton } from "../../ui/Button";
 import Tooltip from "../../ui/Tooltip";
 import MenuCombobox from "./MenuCombobox";
+import { MENU_DEFAULT_LABEL_NEW_ITEM, MENU_DEFAULT_LABEL_NEW_CHILD } from "./utils/menuUtils";
 
 // SortableItem component - memoized
 const SortableItem = memo(function SortableItem({
@@ -81,11 +82,16 @@ const SortableItem = memo(function SortableItem({
       const page = pages.find((p) => p.value === value);
 
       if (page) {
+
+        const trimmedLabel = String(item.label ?? "").trim();
+        const isDefaultLabel = !trimmedLabel || trimmedLabel === MENU_DEFAULT_LABEL_NEW_ITEM || trimmedLabel === MENU_DEFAULT_LABEL_NEW_CHILD;
+
         // User selected an internal page - store pageUuid and derive link from current slug
         onEdit(item.id, {
           ...item,
           pageUuid: page.value,
           link: `${page.slug}.html`,
+          label: isDefaultLabel ? page.label : item.label 
         });
       } else {
         // Custom URL - explicitly clear pageUuid because menu item updates are merged.

--- a/src/components/menus/MenuEditor/index.jsx
+++ b/src/components/menus/MenuEditor/index.jsx
@@ -15,7 +15,7 @@ import { debounce, isEqual } from "lodash";
 import Button from "../../ui/Button";
 import SortableList from "./SortableList";
 import DragOverlayComponent from "./DragOverlay";
-import { ensureIds, findItemById, getItemAtPath, generateId } from "./utils/menuUtils";
+import { ensureIds, findItemById, getItemAtPath, generateId, MENU_DEFAULT_LABEL_NEW_ITEM, MENU_DEFAULT_LABEL_NEW_CHILD } from "./utils/menuUtils";
 import {
   flattenTree,
   getProjection,
@@ -307,7 +307,7 @@ function MenuEditor({ initialItems = [], onChange, onDeleteItem }) {
       ...prevItems,
       {
         id: generateId(),
-        label: "New Item",
+        label: MENU_DEFAULT_LABEL_NEW_ITEM,
         link: "",
         items: [],
       },
@@ -412,7 +412,7 @@ function MenuEditor({ initialItems = [], onChange, onDeleteItem }) {
         // Add the new child
         parentItem.items.push({
           id: generateId(),
-          label: "New Child",
+          label: MENU_DEFAULT_LABEL_NEW_CHILD,
           link: "",
           items: [],
         });

--- a/src/components/menus/MenuEditor/utils/menuUtils.js
+++ b/src/components/menus/MenuEditor/utils/menuUtils.js
@@ -1,5 +1,8 @@
 import { v4 as uuidv4 } from "uuid";
 
+export const MENU_DEFAULT_LABEL_NEW_ITEM = "New Item";
+export const MENU_DEFAULT_LABEL_NEW_CHILD = "New Child";
+
 // Generate a unique ID
 export const generateId = () => `item-${uuidv4()}`;
 


### PR DESCRIPTION
## Issue
Creating a menu item will set the `label` to "New Item" or "New Child".
Then, you have to edit the `label` manually once you set a page.

## Solution
Menu item's `label` will now change to the assign page's one if:
- The label was "New Item" or "New Child"
- The label was empty

If it was anything else, it won't change.

<img width="800" height="539" alt="CleanShot 2026-05-10 at 00 39 21" src="https://github.com/user-attachments/assets/81fa9528-0dcc-4320-a857-52b4e89f6154" />

Also, moved the default texts to `menuUtils.js` file as shared constants.

### Potential issue:
If a user **intentionally** sets the label to exactly "New Item" or "New Child" and then picks an internal page, we'd still overwrite with page.label. That’s rare but possible.